### PR TITLE
Add live site link to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,4 +2,6 @@
 
 Static marketing page for the Flight Snap extension.
 
+Visit the live site at [https://vtoool.github.io/ktflanding/](https://vtoool.github.io/ktflanding/).
+
 GitHub Pages is configured to publish from the `docs/` folder.


### PR DESCRIPTION
## Summary
- add a link to the live GitHub Pages deployment in the README for easy access

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68d40406a9488326aaeed3709b935049