### PR TITLE
Update hero badge copy and time-savings metrics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,7 +107,7 @@
             </div>
           </div>
           <div class="floating-badge">
-            <span>Trusted by travel desks in Moldova, Romania, and beyond</span>
+            <span>Trusted by travel desks in Moldova, Romania, and beyond.</span>
           </div>
         </div>
       </div>
@@ -142,7 +142,7 @@
               <li>Hunting for availability formats in chat threads</li>
               <li>Copy-paste errors that slow down approvals</li>
             </ul>
-            <div class="time-tag">4–7 minutes per option</div>
+            <div class="time-tag">40 seconds – 5 minutes per option</div>
           </article>
           <article class="comparison-card highlight">
             <h3>After Flight Snap</h3>
@@ -152,7 +152,7 @@
               <li>Journey-level buttons keep multi-city output precise</li>
               <li>Cabin detection adjusts defaults unless you lock them</li>
             </ul>
-            <div class="time-tag">30–60 seconds per option</div>
+            <div class="time-tag">5 seconds per option</div>
           </article>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add punctuation to the floating trust badge for consistency
- update time comparison copy to reflect new 40-second-to-5-minute and 5-second metrics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4339c02688326956cdafc0078def1