### PR TITLE
Improve mobile navigation

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,6 +1,9 @@
 const root = document.documentElement;
 const themeToggle = document.getElementById('themeToggle');
 const storedTheme = localStorage.getItem('flight-snap-theme');
+const menuToggle = document.getElementById('menuToggle');
+const primaryNav = document.getElementById('primaryNav');
+const navBackdrop = document.querySelector('[data-nav-backdrop]');
 
 if (storedTheme) {
   root.setAttribute('data-theme', storedTheme);
@@ -13,6 +16,59 @@ themeToggle?.addEventListener('click', () => {
   localStorage.setItem('flight-snap-theme', next);
   themeToggle.setAttribute('aria-pressed', next === 'dark');
 });
+
+const closeNav = () => {
+  if (!menuToggle || !primaryNav) return;
+  menuToggle.classList.remove('is-active');
+  menuToggle.setAttribute('aria-expanded', 'false');
+  primaryNav.classList.remove('is-open');
+  navBackdrop?.classList.remove('is-active');
+  document.body.classList.remove('nav-open');
+};
+
+const openNav = () => {
+  if (!menuToggle || !primaryNav) return;
+  menuToggle.classList.add('is-active');
+  menuToggle.setAttribute('aria-expanded', 'true');
+  primaryNav.classList.add('is-open');
+  navBackdrop?.classList.add('is-active');
+  document.body.classList.add('nav-open');
+};
+
+menuToggle?.addEventListener('click', () => {
+  if (!primaryNav) return;
+  const shouldOpen = !primaryNav.classList.contains('is-open');
+  if (shouldOpen) {
+    openNav();
+  } else {
+    closeNav();
+  }
+});
+
+navBackdrop?.addEventListener('click', closeNav);
+
+primaryNav?.querySelectorAll('a').forEach((link) => {
+  link.addEventListener('click', closeNav);
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && primaryNav?.classList.contains('is-open')) {
+    closeNav();
+  }
+});
+
+const desktopQuery = window.matchMedia('(min-width: 901px)');
+const handleDesktopChange = (event) => {
+  if (event.matches) {
+    closeNav();
+  }
+};
+
+if (desktopQuery.addEventListener) {
+  desktopQuery.addEventListener('change', handleDesktopChange);
+} else if (desktopQuery.addListener) {
+  desktopQuery.addListener(handleDesktopChange);
+}
 
 const year = document.getElementById('year');
 if (year) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
         </span>
         <span class="brand-name">Flight Snap</span>
       </a>
-      <nav class="primary-nav" aria-label="Primary">
+      <nav class="primary-nav" aria-label="Primary" id="primaryNav">
         <a href="#demo">Live Demo</a>
         <a href="#how-it-works">How it works</a>
         <a href="#features">Features</a>
@@ -28,6 +28,10 @@
         <a href="#faq">FAQ</a>
       </nav>
       <div class="nav-actions">
+        <button id="menuToggle" class="icon-button menu-toggle" type="button" aria-expanded="false" aria-controls="primaryNav" aria-label="Toggle navigation menu">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="sr-only">Toggle navigation</span>
+        </button>
         <button id="themeToggle" class="icon-button" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">
           <span class="icon-sun" aria-hidden="true"></span>
           <span class="icon-moon" aria-hidden="true"></span>
@@ -36,6 +40,7 @@
         <a class="btn btn-primary" href="#pricing">Try Free for 7 Days</a>
       </div>
     </div>
+    <div class="nav-backdrop" data-nav-backdrop aria-hidden="true"></div>
   </header>
 
   <main id="main">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -86,6 +86,18 @@ a:focus {
   top: 16px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .container {
   width: min(1100px, 92vw);
   margin: 0 auto;
@@ -163,6 +175,53 @@ a:focus {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.menu-toggle {
+  display: none;
+  position: relative;
+}
+
+.menu-icon {
+  position: relative;
+}
+
+.menu-icon,
+.menu-icon::before,
+.menu-icon::after {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.menu-icon::before,
+.menu-icon::after {
+  content: "";
+  position: absolute;
+  left: 0;
+}
+
+.menu-icon::before {
+  top: -6px;
+}
+
+.menu-icon::after {
+  top: 6px;
+}
+
+.menu-toggle.is-active .menu-icon {
+  transform: rotate(45deg);
+}
+
+.menu-toggle.is-active .menu-icon::before {
+  transform: translateY(6px) rotate(90deg);
+}
+
+.menu-toggle.is-active .menu-icon::after {
+  opacity: 0;
 }
 
 button,
@@ -909,9 +968,54 @@ button,
   }
 }
 
+.nav-backdrop {
+  display: none;
+}
+
+.nav-backdrop.is-active {
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 17, 31, 0.5);
+  backdrop-filter: blur(2px);
+  z-index: 800;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
 @media (max-width: 900px) {
   .primary-nav {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 0;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 1.5rem;
     display: none;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: min(280px, 84vw);
+    z-index: 900;
+  }
+
+  .primary-nav a {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  .primary-nav.is-open {
+    display: flex;
+  }
+
+  .nav-bar {
+    position: relative;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
   }
 
   .plane-path {
@@ -920,6 +1024,14 @@ button,
 
   .site-header {
     position: sticky;
+  }
+
+  .nav-actions {
+    gap: 0.5rem;
+  }
+
+  .nav-actions .btn-ghost {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a mobile-friendly navigation toggle with backdrop support
- style the header menu, actions, and backdrop for smaller viewports
- close the menu on navigation, backdrop tap, escape, and desktop resize

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4aa6c1ecc83269a6ce3bf225c8d26