### PR TITLE
Fix desktop nav toggle visibility

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -170,11 +170,6 @@ a:focus {
   gap: 0.75rem;
 }
 
-.menu-toggle {
-  display: none;
-  position: relative;
-}
-
 .menu-icon {
   position: relative;
 }
@@ -277,6 +272,11 @@ button,
   background: var(--color-surface);
   color: var(--color-text);
   border: 1px solid var(--color-border);
+}
+
+.menu-toggle {
+  display: none;
+  position: relative;
 }
 
 .icon-button:hover,


### PR DESCRIPTION
## Summary
- ensure the hamburger menu toggle remains hidden on larger viewports by moving its rule below the generic icon button styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70a42dbc08326b9cb0a6737dc6ddb