### PR TITLE
Add Paddle sandbox checkout button

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -378,3 +378,16 @@ window.addEventListener('blur', () => {
     stopRandomize();
   }
 });
+
+const proCheckoutButton = document.getElementById('proPlanCheckout');
+const paddleItems = [{ priceId: 'pri_test_replace_with_your_price_id', quantity: 1 }];
+
+proCheckoutButton?.addEventListener('click', () => {
+  if (typeof Paddle === 'undefined' || !Paddle?.Checkout?.open) {
+    console.warn('Paddle checkout is not available.');
+    showToast('Checkout unavailable. Please try again.');
+    return;
+  }
+
+  Paddle.Checkout.open({ items: paddleItems });
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
+  <script>
+    Paddle.Environment.set('sandbox');
+    Paddle.Initialize({
+      token: 'test_xxx_replace_with_your_client_side_token',
+      eventCallback: (event) => console.log('[Paddle]', event)
+    });
+  </script>
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to main content</a>
@@ -215,7 +223,7 @@
               <li>Saved templates &amp; macros</li>
               <li>Priority support</li>
             </ul>
-            <a class="btn btn-primary" href="#">Upgrade to Pro</a>
+            <button class="btn btn-primary" type="button" id="proPlanCheckout">Upgrade to Pro</button>
           </article>
           <article class="pricing-card">
             <h3>Agency</h3>


### PR DESCRIPTION
## Summary
- load Paddle v2 checkout script in sandbox mode with a placeholder test token and event logging
- wire the Pro pricing button to open a Paddle overlay using a configurable test price ID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b7c616648326bf9f02b7f6a7cf40