### PR TITLE
Configure Paddle sandbox credentials

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,9 @@
   <script>
     window.flightSnapPaddleConfig = {
       environment: 'sandbox',
-      token: 'test_xxx_replace_with_your_client_side_token',
-      priceId: 'pri_test_replace_with_your_price_id'
+      token: 'test_9f821587e5b06e1e5a233ef426e',
+      priceId: 'pri_01k6b13zc4vvnh1j7as2ng0834',
+      productId: 'pro_01k6b12q9gf1xvbhxftcggrae4'
     };
   </script>
   <script src="https://cdn.paddle.com/paddle/v2/paddle.js" defer></script>


### PR DESCRIPTION
## Summary
- update the embedded Paddle checkout configuration to use the provided sandbox client token, price, and product identifiers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daa4d35acc83268e55fc36eb6c3150