### PR TITLE
Increase airline logo size

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -839,9 +839,13 @@ body.legal .site-header {
 }
 
 .airline-logo {
-  height: 18px;
+  height: 24px;
+  max-height: 24px;
   width: auto;
   object-fit: contain;
+  flex-shrink: 0;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .chip {


### PR DESCRIPTION
## Summary
- increase the base airline logo height to 24px and prevent shrinking to keep chips aligned

## Testing
- not run

## QA Checklist
- [ ] 4 icons are white checkmarks on blue, matching *I pressed style.
- [ ] Pressing *I copies text, **no “Copied” pill** shows.
- [ ] Clipboard simulator has no horizontal scroll at 1280×800 and 1536×864.
- [ ] Brand reads “FareSnap” everywhere in UI; logo is inline SVG; dark/light OK.
- [ ] No unrelated files changed; build passes; a11y labels intact.

------
https://chatgpt.com/codex/tasks/task_e_68f57e22f0988326a87eb0c6a852684e