### PR TITLE
Increase airline logo prominence

### DIFF
--- a/docs/sandbox/kayak/kayak.css
+++ b/docs/sandbox/kayak/kayak.css
@@ -195,8 +195,8 @@
 }
 
 #kayak-sandbox .airline-logo {
-  width: 44px;
-  height: 36px;
+  width: 60px;
+  height: 48px;
   object-fit: contain;
 }
 
@@ -522,7 +522,7 @@
 
 /* Badges smaller */
 #kayak-sandbox.compact .badges{ gap: 6px; }
-#kayak-sandbox.compact .airline-logo{ height: 14px; }
+#kayak-sandbox.compact .airline-logo{ height: 18px; }
 #kayak-sandbox.compact .chip{ font-size: 11px; padding: 2px 6px; }
 #kayak-sandbox.compact .chip.warn{ padding: 2px 6px; }
 
@@ -593,7 +593,7 @@
 
 /* Badges smaller */
 #kayak-sandbox.compactStack .badges{ gap: 6px; }
-#kayak-sandbox.compactStack .airline-logo{ height: 12px; }
+#kayak-sandbox.compactStack .airline-logo{ height: 16px; }
 #kayak-sandbox.compactStack .chip{ font-size: 11px; padding: 2px 6px; }
 #kayak-sandbox.compactStack .chip.warn{ padding: 2px 6px; }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -839,8 +839,8 @@ body.legal .site-header {
 }
 
 .airline-logo {
-  height: 24px;
-  max-height: 24px;
+  height: 32px;
+  max-height: 32px;
   width: auto;
   object-fit: contain;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- enlarge the default airline badge styling so carriers are more visible
- expand sandbox airline logo dimensions, including compact variants, to match the larger treatment

## Testing
- not run (not requested)

## QA Checklist
- [ ] 4 icons are white checkmarks on blue, matching *I pressed style.
- [ ] Pressing *I copies text, **no “Copied” pill** shows.
- [ ] Clipboard simulator has no horizontal scroll at 1280×800 and 1536×864.
- [ ] Brand reads “FareSnap” everywhere in UI; logo is inline SVG; dark/light OK.
- [ ] No unrelated files changed; build passes; a11y labels intact.


------
https://chatgpt.com/codex/tasks/task_e_68f57fd05cf08326aed79ef6bb59874e